### PR TITLE
- Add SCREENSHOT_DELAY_SEC to env

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ $ docker run --rm \
 | BASIC_AUTH_USERNAME | Username to pass basic authentication. | - | `null` |
 | BASIC_AUTH_PASSWORD | Password to pass basic authentication. | - | `null` |
 | COOKIES | JSON Array string to pass to browser. | - | `null` |
+| SCREENSHOT_DELAY_SEC | Number of seconds to delay time to take screenshot. | - | `null` |
 
 Example of COOKIES
 

--- a/main.js
+++ b/main.js
@@ -46,6 +46,11 @@ async function loginWithCookie(page, cookiesStr) {
   //// disable default viewport
   // see https://github.com/GoogleChrome/puppeteer/issues/1183
   await page._client.send('Emulation.clearDeviceMetricsOverride');
+
+  // Wait delay
+  if (process.env.SCREENSHOT_DELAY_SEC != null) {
+    await page.waitFor(process.env.SCREENSHOT_DELAY_SEC * 1000);
+  }
   await page.screenshot({path: FILE_NAME, fullPage: (FULL_PAGE==='true')});
 
   await browser.close();


### PR DESCRIPTION
- Add SCREENSHOT_DELAY_SEC to environment
  - Use when you want to wait for a screenshot, such as when you need a CSR